### PR TITLE
chore: updates Beacon pod version

### DIFF
--- a/library/ReactNativeHelpScout.podspec
+++ b/library/ReactNativeHelpScout.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.authors      = { 'Dimitar Nestorov': 'opensource@dimitarnestorov.com' }
   s.homepage     = package['homepage']
   s.license      = package['license']
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '11.0'
 
   s.module_name  = 'ReactNativeHelpScout'
 
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'Beacon'
+  s.dependency 'Beacon', '>2'
 
   s.frameworks = 'UIKit'
 

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-native-help-scout",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"main": "./dist/index.js",
 	"typings": "./dist/index.d.ts",
 	"repository": "git@github.com:codemotionapps/react-native-help-scout.git",


### PR DESCRIPTION
Not sure, if you're interested, but quick changes to update the Beacon pod version.

Enables HS chat for iOS by default, but does increase the iOS requirement to iOS 11